### PR TITLE
Support beta(x)

### DIFF
--- a/ci/update-jetpack.js
+++ b/ci/update-jetpack.js
@@ -72,9 +72,9 @@ function incrementPatchVersion(version, skipBeta = false) {
         return '';
     }
     if (!version) {
-        return 1;
+        return '1';
     }
-    return Number(version) + 1;
+    return (Number(version) + 1) + '';
 }
 
 function formatVersion(minor, patch) {

--- a/ci/update-jetpack.js
+++ b/ci/update-jetpack.js
@@ -94,7 +94,6 @@ async function checkVersionExists(version) {
     }
 }
 
-
 async function findPatch(minor) {
     let currentPatch = 'beta';
     let lastPatch = null;
@@ -107,12 +106,11 @@ async function findPatch(minor) {
 
         if (exists) {
             lastPatch = currentPatch;
-            currentPatch = incrementPatchVersion(currentPatch, true);
         } else if(! currentPatch.startsWith('beta')) {
             foundLastPatch = true;
-        } else {
-            currentPatch = incrementPatchVersion(currentPatch, false);
         }
+
+        currentPatch = incrementPatchVersion(currentPatch, exists);
     }
     return lastPatch;
 }

--- a/ci/update-jetpack.js
+++ b/ci/update-jetpack.js
@@ -60,12 +60,10 @@ function compareVersions(a,b) {
     return aParts[2] - bParts[2];
 }
 
-const MAX_BETA = 10;
-
-function incrementPatchVersion(version, skipBeta = false) {
+function incrementPatchVersion(version, versionExists) {
     const betaMatch = version.match(/beta(\d+)?/);
-    const betaNumber = betaMatch && betaMatch[1] ? Number(betaMatch[1]) : 1;
-    if (betaMatch && betaNumber < MAX_BETA && !skipBeta) {
+    if (betaMatch && versionExists) {
+        const betaNumber = betaMatch && betaMatch[1] ? Number(betaMatch[1]) : 1;
         return `beta${betaNumber + 1}`;
     }
     if (betaMatch) {
@@ -109,11 +107,11 @@ async function findPatch(minor) {
 
         if (exists) {
             lastPatch = currentPatch;
-            currentPatch = incrementPatchVersion(currentPatch);
+            currentPatch = incrementPatchVersion(currentPatch, true);
         } else if(! currentPatch.startsWith('beta')) {
             foundLastPatch = true;
         } else {
-            currentPatch = incrementPatchVersion(currentPatch, true);
+            currentPatch = incrementPatchVersion(currentPatch, false);
         }
     }
     return lastPatch;

--- a/ci/update-jetpack.js
+++ b/ci/update-jetpack.js
@@ -115,7 +115,6 @@ async function findPatch(minor) {
         } else {
             currentPatch = incrementPatchVersion(currentPatch, true);
         }
-        console.log('incrementED', currentPatch);
     }
     return lastPatch;
 }
@@ -255,7 +254,7 @@ async function main() {
     let updatedSomething = false;
 
     updatedSomething = await maybeUpdateVersions();
-    // updatedSomething = await maybeDeleteRemovedVersions() || updatedSomething;
+    updatedSomething = await maybeDeleteRemovedVersions() || updatedSomething;
 
     if (updatedSomething) {
         persistConfig();


### PR DESCRIPTION
The current script will not look for beta2, beta3 and so on. This change makes it to look for those before moving to "0" version