### PR TITLE
fix: Update path in .dockerignore so that rsync could use it

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 .dockerignore
-./config.json
+/config.json
 
 .git
 .github


### PR DESCRIPTION
rsync does not like the leading './', as it does not match anything.