### PR TITLE
CI: Install dependencies for update-deps workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -19,7 +19,15 @@ jobs:
           submodules: recursive
 
       - name: Setup Node
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.6.0
+        with:
+          cache: npm
+          node-version: lts/*
+          cache-dependency-path: ci/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ci
 
       - name: Run update
         env:


### PR DESCRIPTION
We previously had `node_modules` committed in the `ci` folder, which is why it is now failing after https://github.com/Automattic/vip-go-mu-plugins-ext/pull/20.