### PR TITLE
Automate posting to lobby when new Jetpack beta is added or released

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -32,4 +32,5 @@ jobs:
       - name: Run update
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          LOBBY_VIP_TOKEN: ${{ secrets.LOBBY_VIP_TOKEN }}
         run: node ./ci/update-deps.js

--- a/ci/package-lock.json
+++ b/ci/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "^0.27.2"
+        "axios": "^0.27.2",
+        "marked": "^4.3.0"
       }
     },
     "node_modules/asynckit": {
@@ -77,6 +78,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -139,6 +151,11 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
     },
     "mime-db": {
       "version": "1.52.0",

--- a/ci/package.json
+++ b/ci/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^0.27.2"
+    "axios": "^0.27.2",
+    "marked": "^4.3.0"
   }
 }

--- a/ci/update-deps.js
+++ b/ci/update-deps.js
@@ -187,12 +187,8 @@ async function draftJPPost( version, type ) {
 async function fetchChangelog(version) {
     const url = `https://raw.githubusercontent.com/Automattic/jetpack-production/${version}/CHANGELOG.md`;
 
-    try {
-      const response = await axios.get(url);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await axios.get(url);
+    return response.data;
 }
 
 /**

--- a/ci/update-deps.js
+++ b/ci/update-deps.js
@@ -8,7 +8,7 @@ const marked = require('marked');
 
 const CONFIG_FILE = './config.json';
 
-const LOBBY_VIP_TOKEN = process.env.LOBBY_VIP_TOKEN;
+const { LOBBY_VIP_TOKEN } = process.env;
 
 const configFile = fs.readFileSync(CONFIG_FILE, 'utf8');
 const globalConfig = JSON.parse(configFile);

--- a/ci/update-deps.js
+++ b/ci/update-deps.js
@@ -204,8 +204,7 @@ async function fetchChangelog(version) {
  * @returns {string} changelog section for the specified version
  */
 function extractChangelogSection(changelog, version, type) {
-    let regex = null;
-    regex = new RegExp(`^\\s*(## ${version}\\s.*?)^\\s*### Other changes`, 'ms');
+    let regex = new RegExp(`^\\s*(## ${version}\\s.*?)^\\s*### Other changes`, 'ms');
     let match = regex.exec(changelog);
 
     if ( ! match && type === 'release' ) {

--- a/ci/update-deps.js
+++ b/ci/update-deps.js
@@ -156,8 +156,8 @@ async function draftJPPost( version, type ) {
     const section = extractChangelogSection( changelog, version, type );
 
     if ( section ) {
-        let title = '';
-        let content = '';
+        let title;
+        let content;
         if ( type === 'beta' ) {
             title = `Call for Testing: Jetpack ${version}`;
             content = createJPBetaPostContent(version, section);


### PR DESCRIPTION
This grabs the changelog and makes the post when we add a new Jetpack beta version to the repo or when a new Jetpack is released