### PR TITLE
Add vip-block-data-api in vip-integrations folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@ The idea behind this repo is to automate external dependency management while st
 
 Jetpack is a hard dependency on VIP. Unfortunately, Jetpack release cadence (every month) creates burden/toil for us, so we're rebundling Jetpack here in the repo.
 
-# WP-Parsely
+## WP-Parsely
 
 WP-Parsely is another first-party versioned dependency.
+
+# Integrations
+
+VIP-created plugins bundled for easier customer usage.
+
+## VIP Block Data API
+
+The [VIP Block Data API](https://github.com/Automattic/vip-block-data-api/) is a REST API for retrieving block editor posts structured as JSON data. Useful for mapping Gutenberg block content to custom components in decopuled.
 
 # Automation
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Jetpack is a hard dependency on VIP. Unfortunately, Jetpack release cadence (eve
 
 WP-Parsely is another first-party versioned dependency.
 
-# Integrations
+## Integrations
 
 VIP-created plugins bundled for easier customer usage.
 
-## VIP Block Data API
+### VIP Block Data API
 
 The [VIP Block Data API](https://github.com/Automattic/vip-block-data-api/) is a REST API for retrieving block editor posts structured as JSON data. Useful for mapping Gutenberg block content to custom components in decopuled.
 

--- a/config.json
+++ b/config.json
@@ -43,5 +43,13 @@
       "3.7": "3.7.2",
       "3.8": "3.8.4"
     }
+  },
+  "vip-block-data-api": {
+    "repo": "https://github.com/Automattic/vip-block-data-api",
+    "folderPrefix": "vip-integrations/vip-block-data-api-",
+    "lowestVersion": "0.2.1",
+    "skip": [],
+    "ignore": [],
+    "current": {}
   }
 }


### PR DESCRIPTION
Include [vip-block-data-api](https://github.com/Automattic/vip-block-data-api) configuration to be pulled into the `vip-integrations/` folder. I've tested that locally the `folderPrefix` works well with a subfolder as defined in the configuration.

Including plugins in a subfolder has the main advantage that it can help to declutter `vip-go-mu-plugins` - optional integration plugins are not exposed as must-use plugins unless explicitly loaded. Plugins in this folder must be loaded via code.