### PR TITLE
Re-add the Block Data API and update the dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,6 +24,10 @@ README.md
 /jetpack*/vendor/automattic/jetpack-password-checker/vendor/symfony/polyfill-php73/Resources/stubs/JsonException.php
 /jetpack*/vendor/automattic/jetpack-password-checker/vendor/sebastian/resource-operations/build/generate.php
 
+# Files in VIP-Block-Data-API that are giving linting errors due to incompatible PHP versions
+**/vip-block-data-api*/vendor/symfony/polyfill-ctype/bootstrap80.php
+**/vip-block-data-api*/vendor/symfony/polyfill-mbstring/bootstrap80.php
+
 # Parse.ly WordPress Integration
 /wp-parsely-*/.prettierrc
 /wp-parsely-*/bin

--- a/config.json
+++ b/config.json
@@ -44,5 +44,13 @@
       "3.7": "3.7.2",
       "3.8": "3.8.4"
     }
+  },
+  "vip-block-data-api": {
+    "repo": "https://github.com/Automattic/vip-block-data-api",
+    "folderPrefix": "vip-integrations/vip-block-data-api-",
+    "lowestVersion": "1.0.0",
+    "skip": [],
+    "ignore": [],
+    "current": {}
   }
 }


### PR DESCRIPTION
This will re-add the Block Data API to the config.json, but will this time also be accompanied by an updated ignore for the docker building process. The ignore is focused on 2 files - `bootstrap80.php` that fail the linting process. They are not included if the php version is 7.4, so the code itself works fine. But the linter goes in and touches each file which is why it fails.