### PR TITLE
Update incrementVersion() to account for different maximum minor versions 

### DIFF
--- a/ci/update-deps.js
+++ b/ci/update-deps.js
@@ -14,10 +14,11 @@ const configFile = fs.readFileSync(CONFIG_FILE, 'utf8');
 const globalConfig = JSON.parse(configFile);
 console.log('Config', globalConfig);
 
-function incrementVersion(version) {
+function incrementVersion(version, plugin) {
     const [major, minor] = version.split('.').map(Number);
+    const maxMinor = plugin === 'jetpack' ? 9 : 20; // Since Jetpack version minors usually don't go over 9, we need to stop looking and jump to the next major.
     let result = '';
-    if (minor === 9) {
+    if (minor === maxMinor) {
         result = `${major + 1}.0`;
     } else {
         result = `${major}.${minor + 1}`;
@@ -396,7 +397,7 @@ async function maybeUpdateVersions() {
 
                 }
             }
-            currentMinor = incrementVersion(currentMinor);
+            currentMinor = incrementVersion(currentMinor, plugin);
         }
     }
 


### PR DESCRIPTION
Depending on the plugin (specifically, JP), we don't need to look above 9 in minor versions when `incrementVersion()`. For others, they might go above 9, so let's set the maximum to 20.