### PR TITLE
Add the governance plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ VIP-created plugins bundled for easier customer usage.
 
 ### VIP Block Data API
 
-The [VIP Block Data API](https://github.com/Automattic/vip-block-data-api/) is a REST API for retrieving block editor posts structured as JSON data. Useful for mapping Gutenberg block content to custom components in decopuled.
+The [VIP Block Data API](https://github.com/Automattic/vip-block-data-api/) is a REST API for retrieving block editor posts structured as JSON data.
+
+### VIP Governance
+
+[VIP Governance](https://github.com/Automattic/vip-governance-plugin) is a plugin that adds additional governance capabilities to the block editor.
 
 # Automation
 

--- a/config.json
+++ b/config.json
@@ -80,8 +80,6 @@
     "lowestVersion": "1.0",
     "skip": [],
     "ignore": [],
-    "current": {
-      "1.0": "1.0.0"
-    }
+    "current": {}
   }
 }

--- a/config.json
+++ b/config.json
@@ -73,5 +73,15 @@
     "current": {
       "1.0": "1.0.3"
     }
+  },
+  "vip-governance": {
+    "repo": "https://github.com/Automattic/vip-governance",
+    "folderPrefix": "vip-integrations/vip-governance-",
+    "lowestVersion": "1.0",
+    "skip": [],
+    "ignore": [],
+    "current": {
+      "1.0": "1.0.0"
+    }
   }
 }


### PR DESCRIPTION
This PR is meant to add the [VIP Governance Plugin](https://github.com/Automattic/vip-governance-plugin/tree/trunk) plugin to mu-plugins-ext so that it can be made available to all VIP customers, just like the Block Data API.

Corresponding mu-plugins PR can be found [here](https://github.com/Automattic/vip-go-mu-plugins/pull/4907) but this one should be merged first.