### PR TITLE
Remove the current version from the governance plugin

### DIFF
--- a/config.json
+++ b/config.json
@@ -80,8 +80,6 @@
     "lowestVersion": "1.0",
     "skip": [],
     "ignore": [],
-    "current": {
-      "1.0": "1.0.0"
-    }
+    "current": {}
   }
 }


### PR DESCRIPTION
**Description**

The repo was the only thing that needed to be corrected in the previous PR, the current version wasn't to be committed or else the plugin won't be pulled. This corrects that mistake.