### PR TITLE
chore(ci): update actions to recent versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,10 @@ jobs:
     name: Runs the tests
     steps:
       - name: Check out source code
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4.1.1
 
       - name: Setup Node
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v4.0.2
         with:
           cache: npm
           node-version: lts/*

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -14,12 +14,12 @@ jobs:
     name: A job to update Jetpack, Parse.ly and others
     steps:
       - name: Check out source code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v4.1.1
         with:
           submodules: recursive
 
       - name: Setup Node
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v4.0.2
         with:
           cache: npm
           node-version: lts/*


### PR DESCRIPTION
GitHub complains:

* A job to update Jetpack, Parse.ly and others: Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3.0.2, actions/setup-node@v3.6.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
* A job to update Jetpack, Parse.ly and others: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR updates `@actions/checkout` and `@actions/setup-node` to their latest versions.
