### PR TITLE
Jetpack: Noop WAF code - it shouldn't run anyway and prevents upgrading from 11.3 and below to current Jetpacks

### DIFF
--- a/jetpack-11.2/jetpack_vendor/automattic/jetpack-waf/actions.php
+++ b/jetpack-11.2/jetpack_vendor/automattic/jetpack-waf/actions.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack\Waf;
 
 use Automattic\Jetpack\Status\Host;
 
+return; // noop
+
 // We don't want to be anything in here outside WP context.
 if ( ! function_exists( 'add_action' ) ) {
 	return;

--- a/jetpack-11.3/jetpack_vendor/automattic/jetpack-waf/actions.php
+++ b/jetpack-11.3/jetpack_vendor/automattic/jetpack-waf/actions.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack\Waf;
 
 use Automattic\Jetpack\Status\Host;
 
+return; // noop
+
 // We don't want to be anything in here outside WP context.
 if ( ! function_exists( 'add_action' ) ) {
 	return;


### PR DESCRIPTION
Due to Autoloader logic an upgrade from 11.2 and 11.3 to modern Jetpack versions results in a fatal. This should prevent it. 