### PR TITLE
add remote-data-blocks integration to config

### DIFF
--- a/config.json
+++ b/config.json
@@ -90,6 +90,9 @@
     "folderPrefix": "vip-integrations/remote-data-blocks-",
     "lowestVersion": "0.9",
     "skip": [],
-    "ignore": []
+    "ignore": [],
+    "current": {
+      "0.9": "0.9.1"
+    }
   }
 }

--- a/config.json
+++ b/config.json
@@ -84,5 +84,12 @@
     "current": {
       "1.0": "1.0.11"
     }
+  },
+  "remote-data-blocks": {
+    "repo": "https://github.com/Automattic/remote-data-blocks",
+    "folderPrefix": "vip-integrations/remote-data-blocks-",
+    "lowestVersion": "0.9",
+    "skip": [],
+    "ignore": []
   }
 }


### PR DESCRIPTION
This PR adds Remote Data Blocks to the configuration file, enabling the hourly [GitHub Action workflow](https://github.com/Automattic/vip-go-mu-plugins-ext/blob/trunk/.github/workflows/update-deps.yml) to automatically pull in the latest versions of the plugin. 

I've set `0.9` as the lowest supported version, since this is the current release version and I can't think of a reason to behind wanting anything lower. The automation will keep the plugin updated as new versions are released.

_closes vipcms-243_