### PR TITLE
[vip-security-boost] Remove `current` versions from the config since we don't have any versions pulled yet

### DIFF
--- a/config.json
+++ b/config.json
@@ -106,8 +106,6 @@
     "lowestVersion": "0.1",
     "skip": [],
     "ignore": [],
-    "current": {
-      "0.1": "0.1.0"
-    }
+    "current": {}
   }
 }


### PR DESCRIPTION
The pulling of `vip-security-boost` has been failing due to missing current version: https://github.com/Automattic/vip-go-mu-plugins-ext/actions/runs/14264919989/job/39984490900

I assumed we were supposed to add it manually, but looking at the commit history, it seems the automation adds it for us.