### PR TITLE
Update the version of the RDB plugin

### DIFF
--- a/config.json
+++ b/config.json
@@ -90,13 +90,12 @@
     "repo": "https://github.com/Automattic/remote-data-blocks",
     "folderPrefix": "vip-integrations/remote-data-blocks-",
     "versionPrefix": "v",
-    "lowestVersion": "0.9",
+    "lowestVersion": "0.11",
     "releaseZipFileName": "remote-data-blocks",
     "skip": [],
     "ignore": [],
     "current": {
-      "0.9": "0.9.1",
-      "0.10": "0.10.0"
+      "0.11": "0.11.0"
     }
   },
   "vip-security-boost": {

--- a/config.json
+++ b/config.json
@@ -94,9 +94,7 @@
     "releaseZipFileName": "remote-data-blocks",
     "skip": [],
     "ignore": [],
-    "current": {
-      "0.11": "0.11.0"
-    }
+    "current": {}
   },
   "vip-security-boost": {
     "repo": "https://github.com/Automattic/vip-security-boost-integration",


### PR DESCRIPTION
### Description

The purpose of this PR is to update the lowest and latest version of the RDB plugin to be the same. At the moment, v0.11 is the latest version and has enough changes that it can be the lowest version at the moment as well. This will be updated further as the plugin gets closer to release, but this is a good base to work with compared to 0.9 and 0.10.