### PR TITLE
fix the compare for when checking outdated versions

### DIFF
--- a/ci/update-deps.js
+++ b/ci/update-deps.js
@@ -687,9 +687,7 @@ async function getLowerVersionsThanLowest(folders, plugin) {
       continue;
     }
     const versionNumber = folders[folder].substring(folderPrefix.length);
-    if (
-      -1 === compareVersions(versionNumber, lowestVersion)
-    ) {
+    if ( compareVersions(versionNumber, lowestVersion) < 0 ) {
       lowerVersions.push(versionNumber);
     }
   }


### PR DESCRIPTION
The compare function returns negative values when the second version is greater than the first. The check was for -1 when it should have been checking for < 0. This led to versions older than immediately lower versions not being removed.

Case in point - when we updated the `lowestVersion` for remote-data-blocks to `0.11` from `0.9`, it only ended up removing the `0.10` and kept the `0.9`.