### PR TITLE
Rename repo from `vip-security-boost-integration` to `vip-security-boost`

### DIFF
--- a/config.json
+++ b/config.json
@@ -99,7 +99,7 @@
     }
   },
   "vip-security-boost": {
-    "repo": "https://github.com/Automattic/vip-security-boost-integration",
+    "repo": "https://github.com/Automattic/vip-security-boost",
     "folderPrefix": "vip-integrations/vip-security-boost-",
     "versionPrefix": "v",
     "lowestVersion": "0.1",


### PR DESCRIPTION
We've decided to rename the repo so it matches the naming convention of other integrations.