### PR TITLE
Raise the lowest version of Remote Data Blocks and Block Data API

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,7 +66,7 @@
   "vip-block-data-api": {
     "repo": "https://github.com/Automattic/vip-block-data-api",
     "folderPrefix": "vip-integrations/vip-block-data-api-",
-    "lowestVersion": "1.0",
+    "lowestVersion": "1.3",
     "skip": [],
     "ignore": [],
     "current": {
@@ -91,7 +91,7 @@
     "repo": "https://github.com/Automattic/remote-data-blocks",
     "folderPrefix": "vip-integrations/remote-data-blocks-",
     "versionPrefix": "v",
-    "lowestVersion": "0.11",
+    "lowestVersion": "0.13",
     "releaseZipFileName": "remote-data-blocks",
     "skip": [],
     "ignore": [],


### PR DESCRIPTION
### Description

This will raise the lowest version of Remote Data Blocks and Block Data API to ensure the older versions are deleted.

Note: I accidentally committed this to trunk directly, but I have reverted that since and made it into this PR.