### PR TITLE
Update lowestVersion for vip-security-boost to 1.0

### DIFF
--- a/config.json
+++ b/config.json
@@ -108,7 +108,7 @@
     "repo": "https://github.com/Automattic/vip-security-boost",
     "folderPrefix": "vip-integrations/vip-security-boost-",
     "versionPrefix": "v",
-    "lowestVersion": "0.1",
+    "lowestVersion": "1.0",
     "skip": [],
     "ignore": [],
     "current": {


### PR DESCRIPTION
We recently tagged v1.0.0 of Security Boost. We need to update here too in order for the automation to pick up the new version.