### PR TITLE
Add versionPrefix to vip-block-data-api configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -79,6 +79,7 @@
   "vip-block-data-api": {
     "repo": "https://github.com/Automattic/vip-block-data-api",
     "folderPrefix": "vip-integrations/vip-block-data-api-",
+    "versionPrefix": "v",
     "lowestVersion": "1.3",
     "skip": [],
     "ignore": [],


### PR DESCRIPTION
We recently added [release automation](https://github.com/Automattic/vip-block-data-api/pull/94) to the VIP Block Data API. The new release uses a `v` prefix, e.g. [`v1.4.6`](https://github.com/Automattic/vip-block-data-api/releases/tag/v1.4.6) for tags, but prior releases only used the bare version number as a tag (`1.4.5`).

Due to the change, this has resulted in the Block Data API [failing to upgrade in the integration center](https://github.com/Automattic/vip-block-data-api/issues/92#issuecomment-3716928377). I'm opting to keep the `v` prefix and update our configuration here.