### PR TITLE
Update Block Data API lowestVersion to 1.4 in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -80,11 +80,10 @@
     "repo": "https://github.com/Automattic/vip-block-data-api",
     "folderPrefix": "vip-integrations/vip-block-data-api-",
     "versionPrefix": "v",
-    "lowestVersion": "1.3",
+    "lowestVersion": "1.4",
     "skip": [],
     "ignore": [],
     "current": {
-      "1.3": "1.3.0",
       "1.4": "1.4.5"
     }
   },


### PR DESCRIPTION
The previous changes in https://github.com/Automattic/vip-go-mu-plugins-ext/pull/97 [failed updating](https://github.com/Automattic/vip-go-mu-plugins-ext/actions/runs/20791578837/job/59714765089):

```
Updating vip-block-data-api
{
  repo: 'https://github.com/Automattic/vip-block-data-api',
  folderPrefix: 'vip-integrations/vip-block-data-api-',
  versionPrefix: 'v',
  lowestVersion: '1.3',
  skip: [],
  ignore: [],
  current: { '1.3': '1.3.0', '1.4': '1.4.5' }
}
Checking 1.3
Not found
```

This was due to checking `1.3` for a new version with the `v` prefix, which wasn't added until the latest `v1.4.6` release. After the `1.3` version check failed, `1.4` was skipped. This PR should hopefully fix that step and allow updates to the newly `v`-prefixed tag.