### PR TITLE
Revert Block Data Api prefix configuration changes

### DIFF
--- a/config.json
+++ b/config.json
@@ -80,10 +80,11 @@
     "repo": "https://github.com/Automattic/vip-block-data-api",
     "folderPrefix": "vip-integrations/vip-block-data-api-",
     "versionPrefix": "v",
-    "lowestVersion": "1.4",
+    "lowestVersion": "1.3",
     "skip": [],
     "ignore": [],
     "current": {
+      "1.3": "1.3.0",
       "1.4": "1.4.5"
     }
   },

--- a/config.json
+++ b/config.json
@@ -79,7 +79,6 @@
   "vip-block-data-api": {
     "repo": "https://github.com/Automattic/vip-block-data-api",
     "folderPrefix": "vip-integrations/vip-block-data-api-",
-    "versionPrefix": "v",
     "lowestVersion": "1.3",
     "skip": [],
     "ignore": [],


### PR DESCRIPTION
Revert the changes in https://github.com/Automattic/vip-go-mu-plugins-ext/pull/98 and https://github.com/Automattic/vip-go-mu-plugins-ext/pull/97 which failed to properly update `vip-block-data-api` to a prefixed tag. Instead, we'll change the release format of VIP Block Data API to continue to leave the `v` prefix out.