### PR TITLE
Fix update-deps.js resilience for missing folders

### DIFF
--- a/ci/update-deps.js
+++ b/ci/update-deps.js
@@ -156,11 +156,22 @@ async function maybeUpdateVersion(plugin, minorVersion, version) {
         return false;
       }
 
-      // update
-      execCommand(`git rm -r ${folderRelative}`);
-      execCommand(
-        `git commit -m "Removing ${folderRelative} for subtree replacement to ${version}"`
-      );
+      // update - only remove if folder actually exists
+      const folderExists = fs.existsSync(folder);
+      if (folderExists) {
+        execCommand(`git rm -r ${folderRelative}`);
+        execCommand(
+          `git commit -m "Removing ${folderRelative} for subtree replacement to ${version}"`
+        );
+      } else {
+        console.log(`Folder ${folderRelative} does not exist on disk (config out of sync), skipping removal`);
+      }
+
+      // Ensure parent directory exists for subtree operations
+      const parentDir = path.dirname(folder);
+      if (!fs.existsSync(parentDir)) {
+        fs.mkdirSync(parentDir, { recursive: true });
+      }
 
       if (config.releaseZipFileName) {
         await downloadReleaseZip(plugin, version, folder);
@@ -183,7 +194,12 @@ async function maybeUpdateVersion(plugin, minorVersion, version) {
         }
       }
     } else {
-      // add
+      // add - ensure parent directory exists for subtree operations
+      const parentDir = path.dirname(folder);
+      if (!fs.existsSync(parentDir)) {
+        fs.mkdirSync(parentDir, { recursive: true });
+      }
+
       if (config.releaseZipFileName) {
         await downloadReleaseZip(plugin, version, folder);
         execCommand(`git add ${folderRelative}`);

--- a/config.json
+++ b/config.json
@@ -129,8 +129,6 @@
     "lowestVersion": "0.1",
     "skip": [],
     "ignore": [],
-    "current": {
-      "0.1": "0.1.0"
-    }
+    "current": {}
   }
 }


### PR DESCRIPTION
## Summary

- Check if folder exists before running `git rm` to avoid crashes when config is out of sync
- Ensure parent directories exist before subtree/zip operations (e.g., `vip-integrations/`)
- Fix vip-agentforce config that had `current` populated without the folder existing

## Context

The CI workflow failed with:
```
fatal: pathspec 'vip-integrations/vip-agentforce-0.1' did not match any files
```

**Root cause:** When vip-agentforce was added to `config.json` in #103, the `current` object was pre-populated with `"0.1": "0.1.0"` (my bad). The script assumes `current[version]` means the folder exists (since normally the script itself populates this after successfully adding the folder).

**Fixes:**
1. **Resilience:** Before `git rm`, check if folder actually exists. If not, log a warning and continue (the folder will be created fresh)
2. **Parent dirs:** Ensure parent directory exists before subtree/extraction operations
3. **Config:** Clear the erroneous `current` entry so the script properly adds the folder on next run