### PR TITLE
VIP-2641 Add releaseZipFileName for vip-agentforce

### DIFF
--- a/config.json
+++ b/config.json
@@ -127,6 +127,7 @@
     "folderPrefix": "vip-integrations/vip-agentforce-",
     "versionPrefix": "v",
     "lowestVersion": "0.1",
+    "releaseZipFileName": "vip-agentforce",
     "skip": [],
     "ignore": [],
     "current": {


### PR DESCRIPTION
## Summary

Configures vip-agentforce to use zip downloads instead of git subtree, matching the pattern used by remote-data-blocks and vip-real-time-collaboration.

## Related

- Automattic/vip-agentforce#31 - Updated the release workflow to produce version-less zip filenames