### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/vip-integrations/vip-agentforce-0.1/README.md
+++ b/vip-integrations/vip-agentforce-0.1/README.md
@@ -91,7 +91,7 @@ Please note, for Psalm to work properly you will need to annotate your PHP code.
 
 ## Linting and coding standards
 
-Linting and coding standards are powered by [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) (commonly known as PHPCS) along with WordPress VIP and WordPress core rulesets.
+Linting and coding standards are powered by [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) (commonly known as PHPCS) along with WordPress VIP and WordPress core rulesets.
 
 For more information please refer to the [linting documentation](/docs/linting.md).
 

--- a/vip-integrations/vip-block-data-api-1.4/phpcs.xml.dist
+++ b/vip-integrations/vip-block-data-api-1.4/phpcs.xml.dist
@@ -7,14 +7,14 @@
 	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
 	-->
 	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+	<!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 
 	<!-- What to scan -->
 	<file>.</file>
 
 	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 
 	<!-- Other directories -->
 	<exclude-pattern>\.git/*</exclude-pattern>

--- a/vip-integrations/vip-governance-1.0/.phpcs.xml.dist
+++ b/vip-integrations/vip-governance-1.0/.phpcs.xml.dist
@@ -6,14 +6,14 @@
 	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
 	-->
 	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+	<!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 
 	<!-- What to scan -->
 	<file>.</file>
 
 	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 
 	<!-- Other directories -->
 	<exclude-pattern>\.git/*</exclude-pattern>

--- a/vip-integrations/vip-security-boost-1.0/.phpcs.xml.dist
+++ b/vip-integrations/vip-security-boost-1.0/.phpcs.xml.dist
@@ -6,8 +6,8 @@
 	<!-- Note: this file is only used for local PHPCS checks; the vip-go-ci bot does not read it.
 	To customize the bot's behavior, see https://docs.wpvip.com/vip-code-analysis-bot/customize-the-bot/. -->
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+	<!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 	<!-- For VIP code review items: https://docs.wpvip.com/development-workflow/code-review/ -->
 	<!-- For VIP PHPCS severity levels: https://docs.wpvip.com/php_codesniffer/phpcs-report/ -->
 
@@ -18,7 +18,7 @@
 	<file>./class-loader.php</file>
 	<file>./vip-security-boost.php</file>
 	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>./node_modules/</exclude-pattern>
 	<exclude-pattern>./vendor/</exclude-pattern>
 
@@ -34,7 +34,7 @@
 	Default PHPCS severity is 5 for errors/warnings.
 
 	PHPCS severity config:
-	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#changing-the-default-severity-levels
+	https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options#changing-the-default-severity-levels
 
 	VIP Code Analysis Bot customization:
 	https://docs.wpvip.com/vip-code-analysis-bot/customize-the-bot/#h-phpcs-severity

--- a/vip-integrations/vip-security-boost-1.0/README.md
+++ b/vip-integrations/vip-security-boost-1.0/README.md
@@ -91,7 +91,7 @@ Please note, for Psalm to work properly you will need to annotate your PHP code.
 
 ## Linting and coding standards.
 
-Linting and coding standards are powered by [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) (commonly known as PHPCS) along with WordPress VIP and WordPress core rulesets.
+Linting and coding standards are powered by [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) (commonly known as PHPCS) along with WordPress VIP and WordPress core rulesets.
 
 For more information please refer to the [linting documentation](/docs/linting.md).
 

--- a/vip-integrations/vip-security-boost-1.0/docs/linting.md
+++ b/vip-integrations/vip-security-boost-1.0/docs/linting.md
@@ -18,7 +18,7 @@ To run PHPCS, navigate to the directory where the relevant `.phpcs.xml.dist` liv
 vendor/bin/phpcs
 ```
 
-See the [PHPCS documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage) (or run `phpcs -h`) for the available command line arguments.
+See the [PHPCS documentation](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage) (or run `phpcs -h`) for the available command line arguments.
 
 ## PHPStan for static analysis
 

--- a/wp-parsely-3.15/.phpcs.xml.dist
+++ b/wp-parsely-3.15/.phpcs.xml.dist
@@ -2,20 +2,20 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wp-parsely" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<description>Custom ruleset for wp-parsely plugin.</description>
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+	<!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 
 	<!-- What to scan -->
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>/build/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 
 	<!-- How to scan -->
-	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- Usage instructions: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
+	<!-- Annotated ruleset: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
 	<!-- Show sniff and progress -->
 	<arg value="sp"/>
 	<!-- Strip the file paths down to the relevant bit -->

--- a/wp-parsely-3.16/.phpcs.xml.dist
+++ b/wp-parsely-3.16/.phpcs.xml.dist
@@ -2,20 +2,20 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wp-parsely" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<description>Custom ruleset for wp-parsely plugin.</description>
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+	<!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 
 	<!-- What to scan -->
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>/build/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 
 	<!-- How to scan -->
-	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- Usage instructions: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
+	<!-- Annotated ruleset: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
 	<!-- Show sniff and progress -->
 	<arg value="sp"/>
 	<!-- Strip the file paths down to the relevant bit -->

--- a/wp-parsely-3.17/.phpcs.xml.dist
+++ b/wp-parsely-3.17/.phpcs.xml.dist
@@ -2,20 +2,20 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wp-parsely" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<description>Custom ruleset for wp-parsely plugin.</description>
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+	<!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 
 	<!-- What to scan -->
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>/build/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 
 	<!-- How to scan -->
-	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- Usage instructions: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
+	<!-- Annotated ruleset: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
 	<!-- Show sniff and progress -->
 	<arg value="sp"/>
 	<!-- Strip the file paths down to the relevant bit -->

--- a/wp-parsely-3.18/.phpcs.xml.dist
+++ b/wp-parsely-3.18/.phpcs.xml.dist
@@ -2,20 +2,20 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wp-parsely" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<description>Custom ruleset for wp-parsely plugin.</description>
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+	<!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 
 	<!-- What to scan -->
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>/build/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 
 	<!-- How to scan -->
-	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- Usage instructions: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
+	<!-- Annotated ruleset: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
 	<!-- Show sniff and progress -->
 	<arg value="sp"/>
 	<!-- Strip the file paths down to the relevant bit -->

--- a/wp-parsely-3.19/.phpcs.xml.dist
+++ b/wp-parsely-3.19/.phpcs.xml.dist
@@ -2,20 +2,20 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wp-parsely" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<description>Custom ruleset for wp-parsely plugin.</description>
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+	<!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 
 	<!-- What to scan -->
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>/build/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 
 	<!-- How to scan -->
-	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- Usage instructions: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
+	<!-- Annotated ruleset: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
 	<!-- Show sniff and progress -->
 	<arg value="sp"/>
 	<!-- Strip the file paths down to the relevant bit -->

--- a/wp-parsely-3.20/.phpcs.xml.dist
+++ b/wp-parsely-3.20/.phpcs.xml.dist
@@ -2,20 +2,20 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wp-parsely" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<description>Custom ruleset for wp-parsely plugin.</description>
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+	<!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 
 	<!-- What to scan -->
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>/build/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 
 	<!-- How to scan -->
-	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- Usage instructions: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
+	<!-- Annotated ruleset: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
 	<!-- Show sniff and progress -->
 	<arg value="sp"/>
 	<!-- Strip the file paths down to the relevant bit -->

--- a/wp-parsely-3.21/.phpcs.xml.dist
+++ b/wp-parsely-3.21/.phpcs.xml.dist
@@ -2,20 +2,20 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wp-parsely" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<description>Custom ruleset for wp-parsely plugin.</description>
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+	<!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 
 	<!-- What to scan -->
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>/build/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 
 	<!-- How to scan -->
-	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- Usage instructions: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
+	<!-- Annotated ruleset: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
 	<!-- Show sniff and progress -->
 	<arg value="sp"/>
 	<!-- Strip the file paths down to the relevant bit -->

--- a/wp-parsely-3.22/.phpcs.xml.dist
+++ b/wp-parsely-3.22/.phpcs.xml.dist
@@ -2,20 +2,20 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wp-parsely" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<description>Custom ruleset for wp-parsely plugin.</description>
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+	<!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 
 	<!-- What to scan -->
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>/build/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 
 	<!-- How to scan -->
-	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- Usage instructions: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
+	<!-- Annotated ruleset: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
 	<!-- Show sniff and progress -->
 	<arg value="sp"/>
 	<!-- Strip the file paths down to the relevant bit -->


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932