### PR TITLE
Add Safe Publish integration artifact ingestion

### DIFF
--- a/ci/update-deps.js
+++ b/ci/update-deps.js
@@ -471,6 +471,12 @@ If you have any questions, related to this release, please [open a support ticke
 function persistConfig() {
   console.log("Persisting config", globalConfig);
 
+  if (DRY_RUN) {
+    console.log(`[DRY RUN] Would write ${CONFIG_FILE_PATH}`);
+    execCommand('git commit -avm "Update config.json"');
+    return;
+  }
+
   try {
     fs.writeFileSync(CONFIG_FILE_PATH, JSON.stringify(globalConfig, null, 2));
     execCommand('git commit -avm "Update config.json"');

--- a/config.json
+++ b/config.json
@@ -133,5 +133,15 @@
     "current": {
       "0.1": "0.1.9"
     }
+  },
+  "safe-publish": {
+    "repo": "https://github.com/Automattic/safe-publish",
+    "folderPrefix": "vip-integrations/safe-publish-",
+    "versionPrefix": "v",
+    "lowestVersion": "1.0",
+    "releaseZipFileName": "safe-publish",
+    "skip": [],
+    "ignore": [],
+    "current": {}
   }
 }

--- a/config.json
+++ b/config.json
@@ -138,7 +138,7 @@
     "repo": "https://github.com/Automattic/safe-publish",
     "folderPrefix": "vip-integrations/safe-publish-",
     "versionPrefix": "v",
-    "lowestVersion": "1.0",
+    "lowestVersion": "0.0",
     "releaseZipFileName": "safe-publish",
     "skip": [],
     "ignore": [],


### PR DESCRIPTION
## Summary
- add Safe Publish to the vip-go-mu-plugins-ext integration artifact config
- configure release ZIP ingestion from Automattic/safe-publish releases into vip-integrations/safe-publish-*

## Dependencies
- Depends on Safe Publish publishing release ZIP artifacts.

## Testing
- node -e "JSON.parse(require('fs').readFileSync('config.json','utf8')); console.log('config.json OK')"