### PR TITLE
Update VIP RTC artifact to v0.5.1

### DIFF
--- a/vip-integrations/vip-real-time-collaboration-0.5/inc/Settings/Settings.php
+++ b/vip-integrations/vip-real-time-collaboration-0.5/inc/Settings/Settings.php
@@ -57,15 +57,15 @@ final class Settings {
 	 * Remove RTC from Gutenberg's experiments schema so this plugin is the only
 	 * place where the feature can be enabled or disabled.
 	 *
-	 * @param array<string, mixed> $args The setting registration arguments.
+	 * @param mixed                $args The setting registration arguments.
 	 * @param array<string, mixed> $_defaults The default registration arguments.
 	 * @param string               $option_group The setting group.
 	 * @param string               $option_name The setting name.
-	 * @return array<string, mixed> The filtered registration arguments.
+	 * @return mixed The filtered registration arguments.
 	 * @psalm-suppress PossiblyUnusedReturnValue Psalm does not detect usage via add_filter.
 	 */
-	public static function hide_gutenberg_rtc_experiment( array $args, array $_defaults, string $option_group, string $option_name ): array {
-		if ( self::GUTENBERG_EXPERIMENTS_OPTION_NAME !== $option_group || self::GUTENBERG_EXPERIMENTS_OPTION_NAME !== $option_name ) {
+	public static function hide_gutenberg_rtc_experiment( mixed $args, array $_defaults, string $option_group, string $option_name ): mixed {
+		if ( self::GUTENBERG_EXPERIMENTS_OPTION_NAME !== $option_group || self::GUTENBERG_EXPERIMENTS_OPTION_NAME !== $option_name || ! is_array( $args ) ) {
 			return $args;
 		}
 

--- a/vip-integrations/vip-real-time-collaboration-0.5/package.json
+++ b/vip-integrations/vip-real-time-collaboration-0.5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vip-real-time-collaboration",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Real-time collaboration plugin for WordPress VIP",
   "main": "build/index.js",
   "keywords": [

--- a/vip-integrations/vip-real-time-collaboration-0.5/vendor/composer/installed.php
+++ b/vip-integrations/vip-real-time-collaboration-0.5/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'automattic/vip-real-time-collaboration',
         'pretty_version' => 'dev-trunk',
         'version' => 'dev-trunk',
-        'reference' => '9fcf1fcccb727715c58b0e7369c88a3d9fded7c5',
+        'reference' => '39a57e10a538200e1122026f96fb4d8ce4107624',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -22,7 +22,7 @@
         'automattic/vip-real-time-collaboration' => array(
             'pretty_version' => 'dev-trunk',
             'version' => 'dev-trunk',
-            'reference' => '9fcf1fcccb727715c58b0e7369c88a3d9fded7c5',
+            'reference' => '39a57e10a538200e1122026f96fb4d8ce4107624',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/vip-integrations/vip-real-time-collaboration-0.5/vip-real-time-collaboration.php
+++ b/vip-integrations/vip-real-time-collaboration-0.5/vip-real-time-collaboration.php
@@ -6,7 +6,7 @@
  * Author: WPVIP
  * Author URI: https://wpvip.com
  * Text Domain: vip-real-time-collaboration
- * Version: 0.5.0
+ * Version: 0.5.1
  * Requires at least: 6.7
  * Requires PHP: 8.2
  */
@@ -33,7 +33,7 @@ if ( ! vip_real_time_collaboration_pre_init() ) {
 define( 'VIP_REAL_TIME_COLLABORATION__LOADED', true );
 define( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_ROOT', __FILE__ );
 define( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_DIRECTORY', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
-define( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_VERSION', '0.5.0' );
+define( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_VERSION', '0.5.1' );
 
 // Autoloader
 require_once __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary

- Updates `vip-integrations/vip-real-time-collaboration-0.5` from VIP RTC `v0.5.0` to `v0.5.1`.
- Imports the official release artifact without changing its contents.
- Does not add, remove, rebuild, or modify any Gutenberg artifact.

## Deployed-stage versions preserved

- develop: Gutenberg `0.2-20260824`, RTC `0.5`
- staging: Gutenberg `0.2-20260824`, RTC `0.5`
- production: Gutenberg `0.2-20260817`, RTC `0.4`

The corresponding Gutenberg folders and `vip-integrations/vip-real-time-collaboration-0.4` remain present. No stale artifact was removed.

## Runtime change

- Prevents fatal errors during settings registration when another plugin passes legacy non-array setting arguments.

## Validation

- VIP RTC release: https://github.com/Automattic/vip-real-time-collaboration/releases/tag/v0.5.1
- Release asset SHA-256: `821228f988bc1360d7f566367cb5ad43cc9a5afd211706ca8bb4a9d1297ceaf6` (matches the GitHub release digest).
- `unzip -tq vip-real-time-collaboration.zip` passed.
- Confirmed the extracted plugin reports `0.5.1` and contains its built entrypoint and Composer autoloader.
- `cd ci && npm test` passed: 13 tests.
- `git diff --cached --check` passed.
- Confirmed every artifact referenced by develop, staging, and production remains present.

