### PR TITLE
Fix Remote Data Blocks release ZIP extraction

### DIFF
--- a/config.json
+++ b/config.json
@@ -95,6 +95,7 @@
     "versionPrefix": "v",
     "lowestVersion": "1.4",
     "releaseZipFileName": "remote-data-blocks",
+    "releaseZipRootFolder": "remote-data-blocks",
     "skip": [],
     "ignore": [],
     "current": {


### PR DESCRIPTION
## Summary

- configure the Remote Data Blocks dependency to flatten its release ZIP root folder
- ensure future RDB releases place `remote-data-blocks.php` at the integration version directory root

## Why

RDB release ZIPs include a `remote-data-blocks/` root folder starting with v1.6.0. Without `releaseZipRootFolder`, the dependency updater preserves that extra nesting and the VIP integration loader cannot discover the release.

Companion fix for the already-extracted releases: https://github.com/Automattic/vip-go-mu-plugins-ext/pull/142

Fixes https://linear.app/a8c/issue/PLTFRM-2780/remote-data-blocks-integration-has-served-150-since-2026-06-30-161718

## Testing

- `jq empty config.json`
- asserted the RDB config resolves `releaseZipRootFolder` to `remote-data-blocks`
- `npm --prefix ci test` (13 passing)
